### PR TITLE
Fix link to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ var terminal = new Terminal('terminal', {}, {
 ```
 
 This gives us 4 commands: `clear`, `help`, `theme`, and `ver` or `version`.
-[Go ahead and try it out using our live example.](http://sasadjolic.github.com/dom-terminal/example.html)
+[Go ahead and try it out using our live example.](http://sasadjolic.github.io/dom-terminal/example.html)
 
 ## Features
 


### PR DESCRIPTION
I wanted to give this a try, and found out that the demo link uses .com instead of .io